### PR TITLE
Use "git worktree" instead of "git stash" and "git checkout"

### DIFF
--- a/cmd/benchdiff/internal/benchdiff.go
+++ b/cmd/benchdiff/internal/benchdiff.go
@@ -130,10 +130,11 @@ func (c *Benchdiff) runBenchmark(ref, filename, extraArgs string, pause time.Dur
 	if ref == "" {
 		return runCmd(cmd, c.debug())
 	}
-	err = runAtGitRef(c.debug(), c.gitCmd(), c.Path, c.BaseRef, func() {
+	err = runAtGitRef(c.debug(), c.gitCmd(), c.Path, c.BaseRef, func(workPath string) {
 		if pause > 0 {
 			time.Sleep(pause)
 		}
+		cmd.Dir = workPath
 		runErr = runCmd(cmd, c.debug())
 	})
 	if err != nil {

--- a/cmd/benchdiff/internal/benchdiff_test.go
+++ b/cmd/benchdiff/internal/benchdiff_test.go
@@ -12,6 +12,7 @@ import (
 
 func setupTestRepo(t *testing.T, path string) {
 	t.Helper()
+	mustGo(t, path, "mod", "init", "bindiff.test")
 	ex1 := filepath.Join(path, "ex1.go")
 	ex1test := filepath.Join(path, "ex1_test.go")
 	err := ioutil.WriteFile(ex1, []byte(ex1Rev1), 0o600)
@@ -41,7 +42,7 @@ func testInDir(t *testing.T, dir string) {
 }
 
 func TestBenchdiff_Run(t *testing.T) {
-	dir := tmpDir(t)
+	dir := t.TempDir()
 	setupTestRepo(t, dir)
 	testInDir(t, dir)
 	differ := Benchdiff{

--- a/cmd/benchdiff/internal/gitrunner.go
+++ b/cmd/benchdiff/internal/gitrunner.go
@@ -19,11 +19,16 @@ func runGitCmd(debug *log.Logger, gitCmd, repoPath string, args ...string) ([]by
 }
 
 func runAtGitRef(debug *log.Logger, gitCmd, repoPath, ref string, fn func(path string)) error {
-	worktree, err := ioutil.TempDir("", "bindiff")
+	worktree, err := ioutil.TempDir("", "benchdiff")
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(worktree)
+	defer func() {
+		rErr := os.RemoveAll(worktree)
+		if rErr != nil {
+			fmt.Printf("Could not delete temp directory: %s\n", worktree)
+		}
+	}()
 
 	_, err = runGitCmd(debug, gitCmd, repoPath, "worktree", "add", "--quiet", "--detach", worktree, ref)
 	if err != nil {

--- a/cmd/benchdiff/internal/gitrunner_test.go
+++ b/cmd/benchdiff/internal/gitrunner_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Test_runAtGitRef(t *testing.T) {
-	dir := tmpDir(t)
+	dir := t.TempDir()
 	fooPath := filepath.Join(dir, "foo")
 	err := ioutil.WriteFile(fooPath, []byte("OG content"), 0o600)
 	require.NoError(t, err)

--- a/cmd/benchdiff/internal/gitrunner_test.go
+++ b/cmd/benchdiff/internal/gitrunner_test.go
@@ -26,8 +26,8 @@ func Test_runAtGitRef(t *testing.T) {
 		untrackedPath := filepath.Join(workDir, "untracked")
 		_, err = ioutil.ReadFile(untrackedPath)
 		require.Error(t, err)
-		fooPath := filepath.Join(workDir, "foo")
-		got, err = ioutil.ReadFile(fooPath)
+		wdFooPath := filepath.Join(workDir, "foo")
+		got, err = ioutil.ReadFile(wdFooPath)
 		require.NoError(t, err)
 		require.Equal(t, "OG content", string(got))
 	}

--- a/cmd/benchdiff/internal/gitrunner_test.go
+++ b/cmd/benchdiff/internal/gitrunner_test.go
@@ -21,11 +21,12 @@ func Test_runAtGitRef(t *testing.T) {
 	require.NoError(t, err)
 	err = ioutil.WriteFile(fooPath, []byte("new content"), 0o600)
 	require.NoError(t, err)
-	fn := func() {
-		var got, gotUntracked []byte
-		gotUntracked, err = ioutil.ReadFile(untrackedPath)
-		require.NoError(t, err)
-		require.Equal(t, "untracked", string(gotUntracked))
+	fn := func(workDir string) {
+		var got []byte
+		untrackedPath := filepath.Join(workDir, "untracked")
+		_, err = ioutil.ReadFile(untrackedPath)
+		require.Error(t, err)
+		fooPath := filepath.Join(workDir, "foo")
 		got, err = ioutil.ReadFile(fooPath)
 		require.NoError(t, err)
 		require.Equal(t, "OG content", string(got))

--- a/cmd/benchdiff/internal/testutil_test.go
+++ b/cmd/benchdiff/internal/testutil_test.go
@@ -1,33 +1,12 @@
 package internal
 
 import (
-	"io/ioutil"
 	"os"
-	"path/filepath"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-var preserveTmpDir bool
-
-func tmpDir(t *testing.T) string {
-	t.Helper()
-	projectTmp := filepath.FromSlash("../../../tmp")
-
-	err := os.MkdirAll(projectTmp, 0o700)
-	assert.NoError(t, err)
-	tmpdir, err := ioutil.TempDir(projectTmp, "")
-	assert.NoError(t, err)
-	t.Cleanup(func() {
-		if preserveTmpDir {
-			t.Logf("tmp dir preserved at %s", tmpdir)
-			return
-		}
-		assert.NoError(t, os.RemoveAll(tmpdir))
-	})
-	return tmpdir
-}
 
 func mustSetEnv(t *testing.T, env map[string]string) {
 	t.Helper()
@@ -46,5 +25,14 @@ func mustGit(t *testing.T, repoPath string, args ...string) []byte {
 	})
 	got, err := runGitCmd(nil, "git", repoPath, args...)
 	assert.NoErrorf(t, err, "error running git:\noutput: %v", string(got))
+	return got
+}
+
+func mustGo(t *testing.T, path string, args ...string) []byte {
+	t.Helper()
+	cmd := exec.Command("go", args...)
+	cmd.Dir = path
+	got, err := cmd.Output()
+	assert.NoErrorf(t, err, "error running go:\noutput: %v", string(got))
 	return got
 }


### PR DESCRIPTION
Thank you for building this!

This PR switches `runAtGitRef` to using the fantastic `git worktree` command, which creates a new working directory from the current repository, without the overhead of a fresh clone. It has several advantages over `git stash` + `git checkout`: it doesn't modify files in the current working directory, avoiding invalidating builds and confusing editors; it protects from accidental modifications during the benchmark; and guarantees a fresh checkout without untracked files which might modify the behavior of the program.